### PR TITLE
fix optimization of encrypted data

### DIFF
--- a/StringEncryption.cpp
+++ b/StringEncryption.cpp
@@ -309,6 +309,9 @@ struct StringEncryption : public ModulePass {
     for (map<GlobalVariable *, pair<Constant *, GlobalVariable *>>::iterator iter = GV2Keys.begin();
          iter != GV2Keys.end(); ++iter) {
       ConstantDataArray *CastedCDA = cast<ConstantDataArray>(iter->second.first);
+      // Prevent optimization of encrypted data
+      appendToCompilerUsed(*iter->second.second->getParent(),
+                           {iter->second.second});
       // Element-By-Element XOR so the fucking verifier won't complain
       // Also, this hides keys
       for (unsigned i = 0; i < CastedCDA->getType()->getNumElements(); i++) {


### PR DESCRIPTION
Hi, I found a problem when using optnone with global O2. If you enable “indibr” along with “strenc”, then the compiler optimizes the global variable that contains the encrypted data. I added a global variable to the metodata, to prevent this.